### PR TITLE
Add org.opensuse.RebootMgr.service for DBus activation

### DIFF
--- a/dbus/Makefile.am
+++ b/dbus/Makefile.am
@@ -4,9 +4,11 @@
 
 busconfigdir = $(datadir)/dbus-1/system.d
 introspectiondir = $(datadir)/dbus-1/interfaces
+systemservicedir = $(datadir)/dbus-1/system-services
 
 busconfig_DATA = org.opensuse.RebootMgr.conf
 introspection_DATA = org.opensuse.RebootMgr.xml
+systemservice_DATA = org.opensuse.RebootMgr.service
 
 xmllint:
 	for F in $(introspection_DATA) $(busconfig_DATA) ; do \

--- a/dbus/org.opensuse.RebootMgr.service
+++ b/dbus/org.opensuse.RebootMgr.service
@@ -1,0 +1,5 @@
+[D-BUS Service]
+Name=org.opensuse.RebootMgr
+Exec=/usr/sbin/rebootmgrd
+User=root
+SystemdService=rebootmgr.service


### PR DESCRIPTION
By using dbus activation, rebootmgrd is started on demand instead of causing

Error: The name org.opensuse.RebootMgr was not provided by any .service files